### PR TITLE
feat: Add Windows Arm64 build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,8 +124,8 @@ jobs:
           path: target/wheels
           retention-days: 1
 
-  build-windows:
-    name: Build Windows wheel
+  build-windows-x86_64:
+    name: Build Windows x86_64 wheel
     runs-on: windows-latest
     strategy:
       matrix:
@@ -155,6 +155,46 @@ jobs:
           path: target/wheels
           retention-days: 1
 
+  build-windows-arm64:
+    name: Build Windows Arm64 wheel
+    runs-on: windows-11-arm
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v4
+      # NEW: Explicitly install Rustup and the toolchain for Windows ARM64
+      # The actions-rust-lang/setup-rust-toolchain action is the most reliable way.
+      - name: Install Rustup and Toolchain for Windows Arm64
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          target: aarch64-pc-windows-msvc # Ensure the target is installed
+          override: true # Ensure this toolchain is set as default for the job
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: aarch64-pc-windows-msvc
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          args: --release -i ${{ env.pythonLocation }}\python.exe
+          
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+      - run: uv sync --frozen --no-install-project
+      - run: uv pip install ormsgpack --no-index -f target/wheels
+      - run: uv run --no-sync pytest
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ormsgpack-aarch64-pc-windows-msvc-${{ matrix.python-version }}
+          path: target/wheels
+          retention-days: 1
+          
   build-macos-universal:
     name: Build macOS universal wheel
     strategy:
@@ -212,7 +252,8 @@ jobs:
     needs: [
       build-linux-x86_64,
       build-linux-cross,
-      build-windows,
+      build-windows-x86_64,
+      build-windows-arm64,
       build-macos-universal,
       build-sdist,
     ]


### PR DESCRIPTION
This commit introduces native support for Windows on Arm64 architecture. This enables the library to be built and run natively on devices with Arm processors, improving performance and compatibility.

Key changes include:
- Addition of new build configurations for Arm64.